### PR TITLE
fix: settle SyncFuture from an already-finished source future

### DIFF
--- a/graphql_sync_dataloaders/sync_future.py
+++ b/graphql_sync_dataloaders/sync_future.py
@@ -46,7 +46,14 @@ class SyncFuture:
             raise TypeError("Cannot resolve future with itself.")
 
         if isinstance(result, SyncFuture):
-            result.add_done_callback(self.set_result)
+            if result.done():
+                exception = result.exception()
+                if exception is not None:
+                    self.set_exception(exception)
+                else:
+                    self.set_result(result.result())
+            else:
+                result.add_done_callback(self.set_result)
         else:
             self._assert_state(_PENDING)
             self._result = result

--- a/tests/test_sync_future.py
+++ b/tests/test_sync_future.py
@@ -50,3 +50,36 @@ def test_nested_chaining():
     assert f.result() == 1
     assert f2.result() == 2
     assert f3.result() == "2"
+
+
+def test_resolving_with_already_finished_future_propagates_value():
+    """A callback may return a future that has already resolved (e.g. a cache
+    hit whose batch already dispatched). Chaining onto such a future must adopt
+    its value rather than treating it as still pending."""
+    inner = SyncFuture()
+    inner.set_result(42)
+    assert inner.done()
+
+    outer = SyncFuture()
+    chained = outer.then(lambda _: inner)
+    outer.set_result("go")
+
+    assert chained.done()
+    assert chained.result() == 42
+
+
+def test_resolving_with_already_finished_future_propagates_exception():
+    """When a callback returns an already-finished future that failed, the
+    chained future must adopt that exception instead of raising an
+    InvalidStateError while trying to register a callback on it."""
+    inner = SyncFuture()
+    inner.set_exception(ValueError("boom"))
+    assert inner.done()
+
+    outer = SyncFuture()
+    chained = outer.then(lambda _: inner)
+    outer.set_result("go")
+
+    assert chained.done()
+    with pytest.raises(ValueError, match="boom"):
+        chained.result()


### PR DESCRIPTION
🤖: `vp cc --resume e5c9ebd1-9d59-41b8-baae-7e33bf75e179`

## What
- `SyncFuture.set_result` now settles directly from a source future that has already resolved — adopting its exception if it failed, otherwise its value — instead of registering a done-callback on it.
- Regression tests for chaining onto an already-finished future (value + exception cases).

## Why
Registering a done-callback asserts the source is PENDING. When a `.then()` callback returned an already-resolved future (e.g. a dataloader cache hit whose batch already dispatched), this raised `InvalidStateError`, orphaning sibling callbacks and deadlocking GraphQL execution. The pending-source path is unchanged.
