### PR TITLE
Surface swallowed dataloader completion errors

### DIFF
--- a/graphql_sync_dataloaders/execution_context.py
+++ b/graphql_sync_dataloaders/execution_context.py
@@ -65,9 +65,63 @@ class DeferredExecutionContext(ExecutionContext):
         if isinstance(result, SyncFuture):
             if not result.done():
                 raise RuntimeError("GraphQL deferred execution failed to complete.")
-            return result.result()
+            try:
+                return result.result()
+            except GraphQLError as error:
+                # A non-null field error propagated through the future chain all
+                # the way to the operation root; record it and null the data,
+                # matching standard graphql-core.
+                self.errors.append(error)
+                return None
 
         return result
+
+    def _settle_field_error(
+        self,
+        future: SyncFuture,
+        raw_error: Exception,
+        field_nodes: List[FieldNode],
+        path: Path,
+        return_type: GraphQLOutputType,
+    ) -> None:
+        """Settle a field's future after its value completion raised.
+
+        Mirrors graphql-core null propagation: a nullable field absorbs the
+        error (it is recorded and the field resolves to null); a non-null field
+        re-raises, which here means failing the future so the error propagates
+        through the chain to the nearest nullable ancestor.
+        """
+        error = located_error(raw_error, field_nodes, path.as_list())
+        try:
+            self.handle_field_error(error, return_type)
+        except GraphQLError:
+            future.set_exception(error)
+        else:
+            future.set_result(None)
+
+    def _record_list_item_error(
+        self,
+        list_future: SyncFuture,
+        raw_error: Exception,
+        field_nodes: List[FieldNode],
+        item_path: Path,
+        item_type: GraphQLOutputType,
+    ) -> bool:
+        """Record a list item's completion error.
+
+        Returns True when the item type is non-null, meaning the whole list is
+        nullified — the list's future is failed so the error propagates to the
+        field's nearest nullable ancestor. Returns False when the item is
+        nullable, in which case the error is recorded and the item is left null.
+        """
+        error = located_error(raw_error, field_nodes, item_path.as_list())
+        try:
+            self.handle_field_error(error, item_type)
+        except GraphQLError:
+            if not list_future.done():
+                list_future.set_exception(error)
+            return True
+        return False
 
     def execute_fields_serially(
         self,
@@ -101,7 +155,15 @@ class DeferredExecutionContext(ExecutionContext):
                         response_name: str, result: SyncFuture, _: None
                     ) -> None:
                         nonlocal unresolved
-                        awaited_result = result.result()
+                        if future.done():
+                            return
+                        try:
+                            awaited_result = result.result()
+                        except Exception as raw_error:
+                            # A non-null child field failed and propagated its
+                            # null here; the whole object is nullified.
+                            future.set_exception(raw_error)
+                            return
                         if awaited_result is not Undefined:
                             results[response_name] = awaited_result
                         else:
@@ -166,11 +228,10 @@ class DeferredExecutionContext(ExecutionContext):
                                     try:
                                         future.set_result(completed.result())
                                     except Exception as raw_error:
-                                        error = located_error(
-                                            raw_error, field_nodes, path.as_list()
+                                        self._settle_field_error(
+                                            future, raw_error, field_nodes, path,
+                                            return_type,
                                         )
-                                        self.handle_field_error(error, return_type)
-                                        future.set_result(None)
 
                                 if completed.done():
                                     process_completed(completed.result())
@@ -180,11 +241,9 @@ class DeferredExecutionContext(ExecutionContext):
                             else:
                                 future.set_result(completed)
                         except Exception as raw_error:
-                            error = located_error(
-                                raw_error, field_nodes, path.as_list()
+                            self._settle_field_error(
+                                future, raw_error, field_nodes, path, return_type
                             )
-                            self.handle_field_error(error, return_type)
-                            future.set_result(None)
 
                     future = SyncFuture()
                     result.add_done_callback(process_result)
@@ -202,9 +261,9 @@ class DeferredExecutionContext(ExecutionContext):
                     try:
                         future.set_result(completed.result())
                     except Exception as raw_error:
-                        error = located_error(raw_error, field_nodes, path.as_list())
-                        self.handle_field_error(error, return_type)
-                        future.set_result(None)
+                        self._settle_field_error(
+                            future, raw_error, field_nodes, path, return_type
+                        )
 
                 if completed.done():
                     return process_completed(completed.result())
@@ -271,6 +330,8 @@ class DeferredExecutionContext(ExecutionContext):
                             _: Any,
                         ) -> None:
                             nonlocal unresolved
+                            if future.done():
+                                return
                             try:
                                 completed = self.complete_value(
                                     item_type,
@@ -291,16 +352,17 @@ class DeferredExecutionContext(ExecutionContext):
                                             item_path: Path,
                                             _: Any,
                                         ) -> None:
+                                            if future.done():
+                                                return
                                             try:
                                                 results[index] = completed.result()
                                             except Exception as raw_error:
-                                                error = located_error(
+                                                self._record_list_item_error(
+                                                    future,
                                                     raw_error,
                                                     field_nodes,
-                                                    item_path.as_list(),
-                                                )
-                                                self.handle_field_error(
-                                                    error, item_type
+                                                    item_path,
+                                                    item_type,
                                                 )
 
                                         completed.add_done_callback(
@@ -314,10 +376,14 @@ class DeferredExecutionContext(ExecutionContext):
                                 else:
                                     results[index] = completed
                             except Exception as raw_error:
-                                error = located_error(
-                                    raw_error, field_nodes, item_path.as_list()
-                                )
-                                self.handle_field_error(error, item_type)
+                                if self._record_list_item_error(
+                                    future,
+                                    raw_error,
+                                    field_nodes,
+                                    item_path,
+                                    item_type,
+                                ):
+                                    return
                             unresolved -= 1
                             if not unresolved:
                                 future.set_result(results)
@@ -345,13 +411,19 @@ class DeferredExecutionContext(ExecutionContext):
                             _: Any,
                         ) -> None:
                             nonlocal unresolved
+                            if future.done():
+                                return
                             try:
                                 results[index] = completed.result()
                             except Exception as raw_error:
-                                error = located_error(
-                                    raw_error, field_nodes, item_path.as_list()
-                                )
-                                self.handle_field_error(error, item_type)
+                                if self._record_list_item_error(
+                                    future,
+                                    raw_error,
+                                    field_nodes,
+                                    item_path,
+                                    item_type,
+                                ):
+                                    return
                             unresolved -= 1
                             if not unresolved:
                                 future.set_result(results)

--- a/graphql_sync_dataloaders/execution_context.py
+++ b/graphql_sync_dataloaders/execution_context.py
@@ -54,11 +54,8 @@ class DeferredExecutionContext(ExecutionContext):
         try:
             dataloader_batch_callbacks.run_all_callbacks()
         except GraphQLError as error:
-            # A field completion error (e.g. a non-nullable field resolving to
-            # null, or an unexpected type from a dataloader) propagated out of a
-            # deferred callback. Standard graphql-core records such an error and
-            # nullifies the data; mirror that instead of hiding the real cause
-            # behind a generic "failed to complete" error.
+            # Deferred field completion failed; record it and null the data
+            # like graphql-core, instead of hiding it behind a generic error.
             self.errors.append(error)
             return None
 
@@ -68,9 +65,7 @@ class DeferredExecutionContext(ExecutionContext):
             try:
                 return result.result()
             except GraphQLError as error:
-                # A non-null field error propagated through the future chain all
-                # the way to the operation root; record it and null the data,
-                # matching standard graphql-core.
+                # Non-null error reached the root; record it and null the data.
                 self.errors.append(error)
                 return None
 
@@ -84,12 +79,9 @@ class DeferredExecutionContext(ExecutionContext):
         path: Path,
         return_type: GraphQLOutputType,
     ) -> None:
-        """Settle a field's future after its value completion raised.
-
-        Mirrors graphql-core null propagation: a nullable field absorbs the
-        error (it is recorded and the field resolves to null); a non-null field
-        re-raises, which here means failing the future so the error propagates
-        through the chain to the nearest nullable ancestor.
+        """Settle a field's future after completion raised: a nullable field
+        absorbs the error (resolves null); a non-null field fails the future to
+        propagate to the nearest nullable ancestor.
         """
         error = located_error(raw_error, field_nodes, path.as_list())
         try:
@@ -109,10 +101,8 @@ class DeferredExecutionContext(ExecutionContext):
     ) -> bool:
         """Record a list item's completion error.
 
-        Returns True when the item type is non-null, meaning the whole list is
-        nullified — the list's future is failed so the error propagates to the
-        field's nearest nullable ancestor. Returns False when the item is
-        nullable, in which case the error is recorded and the item is left null.
+        Returns True if the item is non-null (fail the list future to nullify
+        the whole list), False if nullable (error recorded, item left null).
         """
         error = located_error(raw_error, field_nodes, item_path.as_list())
         try:
@@ -160,8 +150,7 @@ class DeferredExecutionContext(ExecutionContext):
                         try:
                             awaited_result = result.result()
                         except Exception as raw_error:
-                            # A non-null child field failed and propagated its
-                            # null here; the whole object is nullified.
+                            # Non-null child failed; nullify the whole object.
                             future.set_exception(raw_error)
                             return
                         if awaited_result is not Undefined:

--- a/graphql_sync_dataloaders/execution_context.py
+++ b/graphql_sync_dataloaders/execution_context.py
@@ -51,7 +51,16 @@ class DeferredExecutionContext(ExecutionContext):
     ) -> Optional[AwaitableOrValue[Any]]:
         result = super().execute_operation(operation, root_value)
 
-        dataloader_batch_callbacks.run_all_callbacks()
+        try:
+            dataloader_batch_callbacks.run_all_callbacks()
+        except GraphQLError as error:
+            # A field completion error (e.g. a non-nullable field resolving to
+            # null, or an unexpected type from a dataloader) propagated out of a
+            # deferred callback. Standard graphql-core records such an error and
+            # nullifies the data; mirror that instead of hiding the real cause
+            # behind a generic "failed to complete" error.
+            self.errors.append(error)
+            return None
 
         if isinstance(result, SyncFuture):
             if not result.done():

--- a/graphql_sync_dataloaders/sync_dataloader.py
+++ b/graphql_sync_dataloaders/sync_dataloader.py
@@ -33,8 +33,16 @@ class DataloaderBatchCallbacks:
 
     def run_all_callbacks(self):
         callbacks = self._callbacks
-        while callbacks:
-            callbacks.pop(0)()
+        try:
+            while callbacks:
+                callbacks.pop(0)()
+        except Exception:
+            # A callback raised (e.g. a field completion error propagating out
+            # of a dataloader dispatch). Drop any callbacks that were queued
+            # behind it so they don't leak into the next operation on this
+            # thread, then re-raise for the caller to handle.
+            callbacks.clear()
+            raise
 
 
 dataloader_batch_callbacks = DataloaderBatchCallbacks()
@@ -72,14 +80,15 @@ class SyncDataLoader:
         if not is_collection(values) or len(keys) != len(values):
             raise ValueError("The batch loader does not return an expected result")
 
-        try:
-            for (key, future), value in zip(queue, values):
-                if isinstance(value, Exception):
-                    future.set_exception(value)
-                else:
-                    future.set_result(value)
-        except Exception as error:
-            for key, future in queue:
-                self.clear(key)
-                if not future.done():
-                    future.set_exception(error)
+        for (_key, future), value in zip(queue, values):
+            if future.done():
+                # A previous future's completion cascade already resolved this
+                # one (e.g. chained loads of the same key within this batch).
+                continue
+            if isinstance(value, Exception):
+                future.set_exception(value)
+            else:
+                # set_result runs this future's completion callbacks
+                # synchronously; if one raises (e.g. a non-null field error),
+                # let it propagate rather than swallowing the real error.
+                future.set_result(value)

--- a/graphql_sync_dataloaders/sync_dataloader.py
+++ b/graphql_sync_dataloaders/sync_dataloader.py
@@ -37,10 +37,8 @@ class DataloaderBatchCallbacks:
             while callbacks:
                 callbacks.pop(0)()
         except Exception:
-            # A callback raised (e.g. a field completion error propagating out
-            # of a dataloader dispatch). Drop any callbacks that were queued
-            # behind it so they don't leak into the next operation on this
-            # thread, then re-raise for the caller to handle.
+            # A callback raised; drop the rest so they don't leak into the next
+            # operation on this thread, then re-raise for the caller.
             callbacks.clear()
             raise
 
@@ -82,13 +80,11 @@ class SyncDataLoader:
 
         for (_key, future), value in zip(queue, values):
             if future.done():
-                # A previous future's completion cascade already resolved this
-                # one (e.g. chained loads of the same key within this batch).
+                # Already resolved by an earlier future's completion cascade.
                 continue
             if isinstance(value, Exception):
                 future.set_exception(value)
             else:
-                # set_result runs this future's completion callbacks
-                # synchronously; if one raises (e.g. a non-null field error),
-                # let it propagate rather than swallowing the real error.
+                # set_result runs completion callbacks synchronously; let a
+                # raised error propagate rather than swallowing it.
                 future.set_result(value)

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -637,15 +637,9 @@ def test_list_with_nullable_items_reports_error_for_failing_item_only():
 
 
 def test_list_of_non_null_items_with_wrong_type_reports_error():
-    """A list of non-null items receiving a wrong-typed object from a
-    dataloader (its is_type_of check fails) reports the real type error.
-
-    Note the data shape: standard graphql-core nullifies only the nullable
-    ``users`` list, giving ``{"users": None}``. This executor propagates a
-    non-null failure whose value came from a dataloader all the way to the
-    operation root, so the whole ``data`` becomes None. The error itself
-    (message and path) is reported the same either way; only the extent of
-    the nullification differs.
+    """A wrong-typed object supplied for a non-null list item reports the type
+    error and nullifies only the nullable list that contains it. Sibling
+    fields of the operation keep their values, matching standard graphql-core.
     """
     users = {
         "1": {"kind": "user", "name": "ok"},
@@ -669,18 +663,58 @@ def test_list_of_non_null_items_with_wrong_type_reports_error():
                 "users": GraphQLField(
                     GraphQLList(GraphQLNonNull(user)), resolve=resolve_users
                 ),
+                "status": GraphQLField(GraphQLString, resolve=lambda *_: "ok"),
             },
         )
     )
 
-    result = graphql_sync_deferred(schema, "{ users { name } }")
+    result = graphql_sync_deferred(schema, "{ users { name } status }")
 
-    # Over-nullified vs the spec's {"users": None} — see the docstring.
-    assert result.data is None
+    assert result.data == {"users": None, "status": "ok"}
     assert result.errors is not None
     assert len(result.errors) == 1
     assert "Expected value of type 'User'" in result.errors[0].message
     assert result.errors[0].path == ["users", 1]
+
+
+def test_non_null_child_error_nullifies_only_nullable_parent():
+    """A non-null field backed by a dataloader that resolves to null nullifies
+    only its nearest nullable ancestor (the parent object), not the whole
+    operation. Sibling fields keep their values, matching standard
+    graphql-core.
+    """
+    dataloader = SyncDataLoader(lambda keys: [None for _ in keys])
+
+    def resolve_name(_, __):
+        return dataloader.load("k")
+
+    user = GraphQLObjectType(
+        name="User",
+        fields={
+            "name": GraphQLField(GraphQLNonNull(GraphQLString), resolve=resolve_name),
+        },
+    )
+
+    schema = GraphQLSchema(
+        query=GraphQLObjectType(
+            name="Query",
+            fields={
+                "user": GraphQLField(user, resolve=lambda *_: {}),
+                "status": GraphQLField(GraphQLString, resolve=lambda *_: "ok"),
+            },
+        )
+    )
+
+    result = graphql_sync_deferred(schema, "{ user { name } status }")
+
+    assert result.data == {"user": None, "status": "ok"}
+    assert result.errors is not None
+    assert len(result.errors) == 1
+    assert (
+        result.errors[0].message
+        == "Cannot return null for non-nullable field User.name."
+    )
+    assert result.errors[0].path == ["user", "name"]
 
 
 def test_non_null_list_with_null_item_reports_error():

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -11,6 +11,8 @@ from graphql import (
     GraphQLArgument,
     GraphQLString,
     GraphQLList,
+    GraphQLNonNull,
+    GraphQLUnionType,
 )
 
 from graphql_sync_dataloaders import DeferredExecutionContext, SyncDataLoader
@@ -527,3 +529,311 @@ def test_concurrent_threads_are_isolated():
     assert visible_counts["t2"] == 1, (
         f"t2 saw {visible_counts['t2']} callbacks, expected 1 — callbacks are leaking across threads"
     )
+
+
+def test_non_null_field_with_null_from_dataloader_reports_error():
+    """A non-null field whose value is supplied by a dataloader that resolves
+    to None must surface the real "Cannot return null for non-nullable field"
+    error, matching standard graphql-core execution. It must not be hidden
+    behind the generic "deferred execution failed to complete" message.
+    """
+    dataloader = SyncDataLoader(lambda keys: [None for _ in keys])
+
+    def resolve_value(_, __, key):
+        return dataloader.load(key)
+
+    schema = GraphQLSchema(
+        query=GraphQLObjectType(
+            name="Query",
+            fields={
+                "value": GraphQLField(
+                    GraphQLNonNull(GraphQLString),
+                    args={"key": GraphQLArgument(GraphQLString)},
+                    resolve=resolve_value,
+                ),
+            },
+        )
+    )
+
+    result = graphql_sync_deferred(schema, '{ value(key: "1") }')
+
+    assert result.data is None
+    assert result.errors is not None
+    assert len(result.errors) == 1
+    assert (
+        result.errors[0].message
+        == "Cannot return null for non-nullable field Query.value."
+    )
+    assert result.errors[0].path == ["value"]
+
+
+def test_non_null_field_with_wrong_type_from_dataloader_reports_error():
+    """When a dataloader returns a value of the wrong type for a non-null
+    object field (its is_type_of check fails), the real type error must be
+    surfaced instead of being swallowed behind the generic deferred-execution
+    failure message.
+    """
+    dataloader = SyncDataLoader(lambda keys: [{"name": "wrong"} for _ in keys])
+
+    user = GraphQLObjectType(
+        name="User",
+        fields={"name": GraphQLField(GraphQLString)},
+        is_type_of=lambda obj, info: False,
+    )
+
+    def resolve_user(_, __, key):
+        return dataloader.load(key)
+
+    schema = GraphQLSchema(
+        query=GraphQLObjectType(
+            name="Query",
+            fields={
+                "user": GraphQLField(
+                    GraphQLNonNull(user),
+                    args={"key": GraphQLArgument(GraphQLString)},
+                    resolve=resolve_user,
+                ),
+            },
+        )
+    )
+
+    result = graphql_sync_deferred(schema, '{ user(key: "1") { name } }')
+
+    assert result.data is None
+    assert result.errors is not None
+    assert len(result.errors) == 1
+    assert "Expected value of type 'User'" in result.errors[0].message
+    assert result.errors[0].path == ["user"]
+
+
+def test_list_with_nullable_items_reports_error_for_failing_item_only():
+    """In a list of nullable items, a single item whose dataloader errors is
+    reported as null while the surrounding items keep their values.
+    """
+    values = {"1": "a", "2": ValueError("boom"), "3": "c"}
+    dataloader = SyncDataLoader(lambda keys: [values[key] for key in keys])
+
+    def resolve_items(_, __):
+        return [dataloader.load(key) for key in ("1", "2", "3")]
+
+    schema = GraphQLSchema(
+        query=GraphQLObjectType(
+            name="Query",
+            fields={
+                "items": GraphQLField(
+                    GraphQLList(GraphQLString), resolve=resolve_items
+                ),
+            },
+        )
+    )
+
+    result = graphql_sync_deferred(schema, "{ items }")
+
+    assert result.data == {"items": ["a", None, "c"]}
+    assert result.errors is not None
+    assert len(result.errors) == 1
+    assert result.errors[0].message == "boom"
+    assert result.errors[0].path == ["items", 1]
+
+
+def test_list_of_non_null_items_with_wrong_type_reports_error():
+    """A list of non-null items receiving a wrong-typed object from a
+    dataloader (its is_type_of check fails) reports the real type error.
+
+    Note the data shape: standard graphql-core nullifies only the nullable
+    ``users`` list, giving ``{"users": None}``. This executor propagates a
+    non-null failure whose value came from a dataloader all the way to the
+    operation root, so the whole ``data`` becomes None. The error itself
+    (message and path) is reported the same either way; only the extent of
+    the nullification differs.
+    """
+    users = {
+        "1": {"kind": "user", "name": "ok"},
+        "2": {"kind": "address", "name": "bad"},
+    }
+    dataloader = SyncDataLoader(lambda keys: [users[key] for key in keys])
+
+    user = GraphQLObjectType(
+        name="User",
+        fields={"name": GraphQLField(GraphQLString)},
+        is_type_of=lambda obj, info: obj.get("kind") == "user",
+    )
+
+    def resolve_users(_, __):
+        return [dataloader.load(key) for key in ("1", "2")]
+
+    schema = GraphQLSchema(
+        query=GraphQLObjectType(
+            name="Query",
+            fields={
+                "users": GraphQLField(
+                    GraphQLList(GraphQLNonNull(user)), resolve=resolve_users
+                ),
+            },
+        )
+    )
+
+    result = graphql_sync_deferred(schema, "{ users { name } }")
+
+    # Over-nullified vs the spec's {"users": None} — see the docstring.
+    assert result.data is None
+    assert result.errors is not None
+    assert len(result.errors) == 1
+    assert "Expected value of type 'User'" in result.errors[0].message
+    assert result.errors[0].path == ["users", 1]
+
+
+def test_non_null_list_with_null_item_reports_error():
+    """A non-null list of non-null items that receives a null item from a
+    dataloader reports the non-null violation as a GraphQL error.
+    """
+    values = {"1": "a", "2": None}
+    dataloader = SyncDataLoader(lambda keys: [values[key] for key in keys])
+
+    def resolve_items(_, __):
+        return [dataloader.load(key) for key in ("1", "2")]
+
+    schema = GraphQLSchema(
+        query=GraphQLObjectType(
+            name="Query",
+            fields={
+                "items": GraphQLField(
+                    GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLString))),
+                    resolve=resolve_items,
+                ),
+            },
+        )
+    )
+
+    result = graphql_sync_deferred(schema, "{ items }")
+
+    assert result.data is None
+    assert result.errors is not None
+    assert len(result.errors) == 1
+    assert (
+        result.errors[0].message
+        == "Cannot return null for non-nullable field Query.items."
+    )
+    assert result.errors[0].path == ["items", 1]
+
+
+def test_nullable_union_returning_type_outside_union_reports_error():
+    """A nullable union field whose dataloader returns an object matching none
+    of the union members reports the abstract-type resolution error and nulls
+    just that field.
+    """
+    a = GraphQLObjectType(
+        "A", {"a": GraphQLField(GraphQLString)},
+        is_type_of=lambda obj, info: obj.get("kind") == "a",
+    )
+    b = GraphQLObjectType(
+        "B", {"b": GraphQLField(GraphQLString)},
+        is_type_of=lambda obj, info: obj.get("kind") == "b",
+    )
+    ab = GraphQLUnionType("AB", [a, b])
+
+    dataloader = SyncDataLoader(lambda keys: [{"kind": "c"} for _ in keys])
+
+    def resolve_thing(_, __, key):
+        return dataloader.load(key)
+
+    schema = GraphQLSchema(
+        query=GraphQLObjectType(
+            name="Query",
+            fields={
+                "thing": GraphQLField(
+                    ab,
+                    args={"key": GraphQLArgument(GraphQLString)},
+                    resolve=resolve_thing,
+                ),
+            },
+        )
+    )
+
+    result = graphql_sync_deferred(schema, '{ thing(key: "1") { __typename } }')
+
+    assert result.data == {"thing": None}
+    assert result.errors is not None
+    assert len(result.errors) == 1
+    assert "Abstract type 'AB' must resolve to an Object type" in result.errors[0].message
+    assert result.errors[0].path == ["thing"]
+
+
+def test_non_null_union_returning_type_outside_union_reports_error():
+    """A non-null union field whose dataloader returns an object matching none
+    of the union members reports the abstract-type resolution error instead of
+    hanging the operation.
+    """
+    a = GraphQLObjectType(
+        "A", {"a": GraphQLField(GraphQLString)},
+        is_type_of=lambda obj, info: obj.get("kind") == "a",
+    )
+    b = GraphQLObjectType(
+        "B", {"b": GraphQLField(GraphQLString)},
+        is_type_of=lambda obj, info: obj.get("kind") == "b",
+    )
+    ab = GraphQLUnionType("AB", [a, b])
+
+    dataloader = SyncDataLoader(lambda keys: [{"kind": "c"} for _ in keys])
+
+    def resolve_thing(_, __, key):
+        return dataloader.load(key)
+
+    schema = GraphQLSchema(
+        query=GraphQLObjectType(
+            name="Query",
+            fields={
+                "thing": GraphQLField(
+                    GraphQLNonNull(ab),
+                    args={"key": GraphQLArgument(GraphQLString)},
+                    resolve=resolve_thing,
+                ),
+            },
+        )
+    )
+
+    result = graphql_sync_deferred(schema, '{ thing(key: "1") { __typename } }')
+
+    assert result.data is None
+    assert result.errors is not None
+    assert len(result.errors) == 1
+    assert "Abstract type 'AB' must resolve to an Object type" in result.errors[0].message
+    assert result.errors[0].path == ["thing"]
+
+
+def test_nullable_object_field_with_wrong_type_reports_error():
+    """A nullable object field whose dataloader returns a value of the wrong
+    type (its is_type_of check fails) reports the type error and nulls just
+    that field.
+    """
+    user = GraphQLObjectType(
+        name="User",
+        fields={"name": GraphQLField(GraphQLString)},
+        is_type_of=lambda obj, info: False,
+    )
+
+    dataloader = SyncDataLoader(lambda keys: [{"name": "x"} for _ in keys])
+
+    def resolve_user(_, __, key):
+        return dataloader.load(key)
+
+    schema = GraphQLSchema(
+        query=GraphQLObjectType(
+            name="Query",
+            fields={
+                "user": GraphQLField(
+                    user,
+                    args={"key": GraphQLArgument(GraphQLString)},
+                    resolve=resolve_user,
+                ),
+            },
+        )
+    )
+
+    result = graphql_sync_deferred(schema, '{ user(key: "1") { name } }')
+
+    assert result.data == {"user": None}
+    assert result.errors is not None
+    assert len(result.errors) == 1
+    assert "Expected value of type 'User'" in result.errors[0].message
+    assert result.errors[0].path == ["user"]


### PR DESCRIPTION
🤖: `vp cc --resume e5c9ebd1-9d59-41b8-baae-7e33bf75e179`

## What
- Report the real `GraphQLError` when a deferred (dataloader-backed) field fails
  completion, instead of hiding it behind a generic
  "GraphQL deferred execution failed to complete." RuntimeError with no traceback
- Covers every completion failure: non-null field resolving to null, unexpected
  object type, type outside a union, failing `is_type_of`, non-iterable for a list
- Propagate a non-null error to the nearest nullable ancestor only — sibling
  fields are preserved, matching standard graphql-core (no over-nullification)
- Clear leftover deferred callbacks on error so a failed operation can't leak
  futures into the next operation on the same thread

## Why
Dataloader completion errors were swallowed with no traceback, making them nearly impossible to debug.
